### PR TITLE
Añadir echo y arreglar posición del año

### DIFF
--- a/arbol.sh
+++ b/arbol.sh
@@ -33,7 +33,7 @@ new_year=$(date +'%Y')
 let new_year++
 tput setaf 1; tput bold
 tput cup $lin $((c - 6)); echo ¡FELIZ NAVIDAD!
-tput cup $((lin + 1)) $((c - 10)); Y próspero año 2020
+tput cup $((lin + 1)) $((c - 10)); echo Y próspero año
 let c++
 k=1
 
@@ -57,7 +57,7 @@ while true; do
         column[$k$i]=$co
         color=$(((color+1)%8))
         # Flashing text
-        sh=1
+        sh=4
         for l in 2 0 2 0
         do
             tput cup $((lin+1)) $((c+sh))


### PR DESCRIPTION
Añado el echo que faltaba en "Y próspero año" y arreglo la posición del año en la frase, que se comía parte de la frase.  

![ezgif-4-2e0e7c893659](https://user-images.githubusercontent.com/16068600/71465647-8280c200-27bd-11ea-96a1-cd473107379f.gif)
